### PR TITLE
Client support for SSL

### DIFF
--- a/ReactiveSockets/ReactiveSocket.cs
+++ b/ReactiveSockets/ReactiveSocket.cs
@@ -94,6 +94,18 @@
         /// </summary>
         public IObservable<byte> Sender { get { return sender; } }
 
+
+        /// <summary>
+        /// Gets the TcpClient stream to use. 
+        /// </summary>
+        /// <remarks>Virtual so it can be overridden to implement SSL</remarks>
+        protected virtual System.IO.Stream GetStream()
+        {
+            return client.GetStream();
+        }
+
+
+
         /// <summary>
         /// Connects the reactive socket using the given TCP client.
         /// </summary>
@@ -207,7 +219,7 @@
         {
             Task.Factory.StartNew(() =>
             {
-                var stream = client.GetStream();
+                var stream = GetStream();
                 var buffer = new byte[128];
                 while (!cancellation.IsCancellationRequested)
                 {
@@ -266,7 +278,7 @@
                 syncLock.EnterWriteLock();
                 try
                 {
-                    var stream = client.GetStream();
+                    var stream = GetStream();
                     Task.Factory.FromAsync<byte[], int, int>(stream.BeginWrite, stream.EndWrite, bytes, 0, bytes.Length, null, TaskCreationOptions.AttachedToParent)
                         .Wait(cancellation);
 

--- a/ReactiveSockets/ReactiveSockets.csproj
+++ b/ReactiveSockets/ReactiveSockets.csproj
@@ -78,6 +78,7 @@
     <Compile Include="ReactiveListener.cs" />
     <Compile Include="ReactiveListenerSettings.cs" />
     <Compile Include="ReactiveSocket.cs" />
+    <Compile Include="ReactiveSslClient.cs" />
     <Compile Include="Tracer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ReactiveSockets/ReactiveSslClient.cs
+++ b/ReactiveSockets/ReactiveSslClient.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace ReactiveSockets
+{
+    /// <summary>
+    /// An SSL-wrapped <see cref="ReactiveClient"/>.
+    /// </summary>
+    public class ReactiveSslClient : ReactiveClient
+    {
+        private SslStream _stream;
+        private readonly object _getStreamLock = new object();
+        
+        private readonly string _targetHost;
+        private readonly bool _leaveInnerStreamOpen;
+        private readonly RemoteCertificateValidationCallback _userCertificateValidationCallback;
+        private readonly LocalCertificateSelectionCallback _userCertificateSelectionCallback;
+        private readonly EncryptionPolicy _encryptionPolicy;
+        private readonly X509CertificateCollection _clientCertificates;
+        private readonly SslProtocols _enabledSslProtocols;
+        private readonly bool _checkCertificateRevocation;
+        
+        
+        /// <summary>
+        /// Initializes the reactive client.
+        /// </summary>
+        /// <param name="hostname">The host name or IP address of the TCP server to connect to.</param>
+        /// <param name="port">The port to connect to.</param>
+        /// <param name="targetHost">The name of the server that will share this <see cref="T:System.Net.Security.SslStream"/>. 
+        /// (From <see cref="SslStream.AuthenticateAsClient(string,System.Security.Cryptography.X509Certificates.X509CertificateCollection,System.Security.Authentication.SslProtocols,bool)"/>)</param>
+        /// <param name="leaveInnerStreamOpen">A Boolean value that indicates the closure behavior of the <see cref="T:System.IO.Stream"/> 
+        /// object used by the <see cref="T:System.Net.Security.SslStream"/> for sending and receiving data. This parameter indicates if the 
+        /// inner stream is left open. (From <see cref="T:System.Net.Security.SslStream"/> constructor)</param>
+        /// <param name="userCertificateValidationCallback">A <see cref="T:System.Net.Security.RemoteCertificateValidationCallback"/> 
+        /// delegate responsible for validating the certificate supplied by the remote party. (From <see cref="T:System.Net.Security.SslStream"/> constructor)</param>
+        /// <param name="userCertificateSelectionCallback">A <see cref="T:System.Net.Security.LocalCertificateSelectionCallback"/> delegate 
+        /// responsible for selecting the certificate used for authentication. (From <see cref="T:System.Net.Security.SslStream"/> constructor)</param>
+        /// <param name="encryptionPolicy">The <see cref="T:System.Net.Security.EncryptionPolicy"/> to use. (From <see cref="T:System.Net.Security.SslStream"/> constructor)</param>
+        /// <param name="clientCertificates">The <see cref="T:System.Security.Cryptography.X509Certificates.X509CertificateCollection"/> that contains client certificates.
+        /// (From <see cref="SslStream.AuthenticateAsClient(string,System.Security.Cryptography.X509Certificates.X509CertificateCollection,System.Security.Authentication.SslProtocols,bool)"/>)</param>
+        /// <param name="enabledSslProtocols">The <see cref="T:System.Security.Authentication.SslProtocols"/> value that represents the protocol used for authentication.
+        /// (From <see cref="SslStream.AuthenticateAsClient(string,System.Security.Cryptography.X509Certificates.X509CertificateCollection,System.Security.Authentication.SslProtocols,bool)"/>)</param>
+        /// <param name="checkCertificateRevocation">A <see cref="T:System.Boolean"/> value that specifies whether the certificate revocation list is checked during authentication.
+        /// (From <see cref="SslStream.AuthenticateAsClient(string,System.Security.Cryptography.X509Certificates.X509CertificateCollection,System.Security.Authentication.SslProtocols,bool)"/>)</param>
+        public ReactiveSslClient(
+            string hostname, 
+            int port, 
+            string targetHost,
+            bool leaveInnerStreamOpen = false,
+            RemoteCertificateValidationCallback userCertificateValidationCallback = null,
+            LocalCertificateSelectionCallback userCertificateSelectionCallback = null,
+            EncryptionPolicy encryptionPolicy = EncryptionPolicy.RequireEncryption,
+            X509CertificateCollection clientCertificates = null,
+            SslProtocols enabledSslProtocols = SslProtocols.Ssl3 | SslProtocols.Tls,
+            bool checkCertificateRevocation = false) 
+            : base(hostname, port)
+        {
+            _targetHost = targetHost;
+            _leaveInnerStreamOpen = leaveInnerStreamOpen;
+            _userCertificateValidationCallback = userCertificateValidationCallback;
+            _userCertificateSelectionCallback = userCertificateSelectionCallback;
+            _encryptionPolicy = encryptionPolicy;
+            _clientCertificates = clientCertificates;
+            _enabledSslProtocols = enabledSslProtocols;
+            _checkCertificateRevocation = checkCertificateRevocation;
+        }
+
+        /// <summary>
+        /// Returns an SSL-wrapped stream. This method always returns the same stream
+        /// object, initialzed when this is first called. This method is thread-safe.
+        /// </summary>
+        /// <returns></returns>
+        protected override System.IO.Stream GetStream()
+        {
+            lock (_getStreamLock)
+            {
+                if (_stream == null)
+                {
+                    _stream = new SslStream(
+                        base.GetStream(),
+                        leaveInnerStreamOpen: _leaveInnerStreamOpen,
+                        userCertificateValidationCallback: _userCertificateValidationCallback,
+                        userCertificateSelectionCallback: _userCertificateSelectionCallback,
+                        encryptionPolicy: _encryptionPolicy);
+
+                    _stream.AuthenticateAsClient(
+                        _targetHost,
+                        _clientCertificates ?? new X509CertificateCollection(),
+                        _enabledSslProtocols,
+                        _checkCertificateRevocation);
+                }
+                return _stream;
+            }
+        }
+    }
+}

--- a/ReactiveSockets/ReactiveSslClient.cs
+++ b/ReactiveSockets/ReactiveSslClient.cs
@@ -13,8 +13,8 @@ namespace ReactiveSockets
     /// </summary>
     public class ReactiveSslClient : ReactiveClient
     {
-        private SslStream _stream;
-        private readonly object _getStreamLock = new object();
+        private SslStream stream;
+        private readonly object getStreamLock = new object();
         
         private readonly string targetHost;
         private readonly bool leaveInnerStreamOpen;
@@ -77,24 +77,24 @@ namespace ReactiveSockets
         /// <returns></returns>
         protected override System.IO.Stream GetStream()
         {
-            lock (_getStreamLock)
+            lock (getStreamLock)
             {
-                if (_stream == null)
+                if (stream == null)
                 {
-                    _stream = new SslStream(
+                    stream = new SslStream(
                         base.GetStream(),
                         leaveInnerStreamOpen: leaveInnerStreamOpen,
                         userCertificateValidationCallback: userCertificateValidationCallback,
                         userCertificateSelectionCallback: userCertificateSelectionCallback,
                         encryptionPolicy: encryptionPolicy);
 
-                    _stream.AuthenticateAsClient(
+                    stream.AuthenticateAsClient(
                         targetHost,
                         clientCertificates ?? new X509CertificateCollection(),
                         enabledSslProtocols,
                         checkCertificateRevocation);
                 }
-                return _stream;
+                return stream;
             }
         }
     }

--- a/ReactiveSockets/ReactiveSslClient.cs
+++ b/ReactiveSockets/ReactiveSslClient.cs
@@ -16,14 +16,14 @@ namespace ReactiveSockets
         private SslStream _stream;
         private readonly object _getStreamLock = new object();
         
-        private readonly string _targetHost;
-        private readonly bool _leaveInnerStreamOpen;
-        private readonly RemoteCertificateValidationCallback _userCertificateValidationCallback;
-        private readonly LocalCertificateSelectionCallback _userCertificateSelectionCallback;
-        private readonly EncryptionPolicy _encryptionPolicy;
-        private readonly X509CertificateCollection _clientCertificates;
-        private readonly SslProtocols _enabledSslProtocols;
-        private readonly bool _checkCertificateRevocation;
+        private readonly string targetHost;
+        private readonly bool leaveInnerStreamOpen;
+        private readonly RemoteCertificateValidationCallback userCertificateValidationCallback;
+        private readonly LocalCertificateSelectionCallback userCertificateSelectionCallback;
+        private readonly EncryptionPolicy encryptionPolicy;
+        private readonly X509CertificateCollection clientCertificates;
+        private readonly SslProtocols enabledSslProtocols;
+        private readonly bool checkCertificateRevocation;
         
         
         /// <summary>
@@ -60,14 +60,14 @@ namespace ReactiveSockets
             bool checkCertificateRevocation = false) 
             : base(hostname, port)
         {
-            _targetHost = targetHost;
-            _leaveInnerStreamOpen = leaveInnerStreamOpen;
-            _userCertificateValidationCallback = userCertificateValidationCallback;
-            _userCertificateSelectionCallback = userCertificateSelectionCallback;
-            _encryptionPolicy = encryptionPolicy;
-            _clientCertificates = clientCertificates;
-            _enabledSslProtocols = enabledSslProtocols;
-            _checkCertificateRevocation = checkCertificateRevocation;
+            this.targetHost = targetHost;
+            this.leaveInnerStreamOpen = leaveInnerStreamOpen;
+            this.userCertificateValidationCallback = userCertificateValidationCallback;
+            this.userCertificateSelectionCallback = userCertificateSelectionCallback;
+            this.encryptionPolicy = encryptionPolicy;
+            this.clientCertificates = clientCertificates;
+            this.enabledSslProtocols = enabledSslProtocols;
+            this.checkCertificateRevocation = checkCertificateRevocation;
         }
 
         /// <summary>
@@ -83,16 +83,16 @@ namespace ReactiveSockets
                 {
                     _stream = new SslStream(
                         base.GetStream(),
-                        leaveInnerStreamOpen: _leaveInnerStreamOpen,
-                        userCertificateValidationCallback: _userCertificateValidationCallback,
-                        userCertificateSelectionCallback: _userCertificateSelectionCallback,
-                        encryptionPolicy: _encryptionPolicy);
+                        leaveInnerStreamOpen: leaveInnerStreamOpen,
+                        userCertificateValidationCallback: userCertificateValidationCallback,
+                        userCertificateSelectionCallback: userCertificateSelectionCallback,
+                        encryptionPolicy: encryptionPolicy);
 
                     _stream.AuthenticateAsClient(
-                        _targetHost,
-                        _clientCertificates ?? new X509CertificateCollection(),
-                        _enabledSslProtocols,
-                        _checkCertificateRevocation);
+                        targetHost,
+                        clientCertificates ?? new X509CertificateCollection(),
+                        enabledSslProtocols,
+                        checkCertificateRevocation);
                 }
                 return _stream;
             }


### PR DESCRIPTION
Adds ReactiveSslClient that wraps a System.Net.Security.SslStream around a client socket stream.
