### PR TITLE
Dispose shouldn't throw after a call to Disconnect

### DIFF
--- a/ReactiveSockets.Tests/TcpClientSocketTests.cs
+++ b/ReactiveSockets.Tests/TcpClientSocketTests.cs
@@ -59,6 +59,20 @@
             }
         }
 
+        [Fact]
+        public void when_calling_dispose_after_disconnect_then_work()
+        {
+            using (var server = new ReactiveListener(1055))
+            {
+                var client = new ReactiveClient("127.0.0.1", 1055);
+                server.Start();
+                client.ConnectAsync().Wait();
+
+                client.Disconnect();
+                client.Dispose();
+            }
+        }
+
         [Fact(Skip = "Does not work from tests.")]
         public void when_reconnecting_then_raises_connected()
         {

--- a/ReactiveSockets/ReactiveSocket.cs
+++ b/ReactiveSockets/ReactiveSocket.cs
@@ -182,6 +182,8 @@
                 cancellation.Dispose();
             }
 
+            cancellation = null;
+
             if (IsConnected)
             {
                 client.Close();


### PR DESCRIPTION
Previously, the cancelation token would throw an ObjectDisposedException
when Disposed is called after Disconnect
