### PR TITLE
Fix MissingMethodException that mysteriously is thrown when the type isn't specified

### DIFF
--- a/ReactiveSockets/ReactiveListener.cs
+++ b/ReactiveSockets/ReactiveListener.cs
@@ -89,7 +89,8 @@
                     connections.Add(socket);
                     observable.OnNext(socket);
 
-                    IDisposable disposeSubscription = Observable.FromEventPattern(h => socket.Disposed += h, h => socket.Disposed -= h)
+                    IDisposable disposeSubscription = Observable.FromEventPattern<EventHandler, EventArgs>(
+                            h => socket.Disposed += h, h => socket.Disposed -= h)
                         .FirstAsync().Subscribe(x =>
                         {
                             Tracer.Log.ReactiveListenerRemovingDisposedSocket();


### PR DESCRIPTION
In my last PR, I used the Observable.FromEventPattern method to listen to the Disposed event.
Somehow, in my application where I use ReactiveSockets, the listener suddenly threw a MissingMethodException but it works fine in ReactiveSocket's unit tests.

Adding the generic types fixes this problem.

Why this solves the problem, or why there was a problem in first place is beyond my comprehension...
