### PR TITLE
Make ReactiveSockets more "Reactive"

### DIFF
--- a/ReactiveSockets.Tests/ReactiveListenerTests.cs
+++ b/ReactiveSockets.Tests/ReactiveListenerTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ReactiveSockets.Tests
+{
+    public class ReactiveListenerTests
+    {
+        [Fact]
+        public void when_disposed_then_complete_connections_observable()
+        {
+            var listener = new ReactiveListener(1055);
+            listener.Start();
+
+            bool completed = false;
+
+            listener.Connections.Subscribe(x => { }, () => completed = true);
+
+            listener.Dispose();
+
+            Assert.True(completed);
+        }
+    }
+}

--- a/ReactiveSockets.Tests/ReactiveListenerTests.cs
+++ b/ReactiveSockets.Tests/ReactiveListenerTests.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace ReactiveSockets.Tests
+﻿namespace ReactiveSockets.Tests
 {
+    using System;
+    using Xunit;
+
     public class ReactiveListenerTests
     {
         [Fact]

--- a/ReactiveSockets.Tests/ReactiveSockets.Tests.csproj
+++ b/ReactiveSockets.Tests/ReactiveSockets.Tests.csproj
@@ -60,6 +60,7 @@
   <ItemGroup>
     <Compile Include="EndToEnd.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReactiveListenerTests.cs" />
     <Compile Include="SampleProtocolTests.cs" />
     <Compile Include="TcpClientSocketTests.cs" />
   </ItemGroup>

--- a/ReactiveSockets.Tests/TcpClientSocketTests.cs
+++ b/ReactiveSockets.Tests/TcpClientSocketTests.cs
@@ -73,6 +73,23 @@
             }
         }
 
+        [Fact]
+        public void when_disposing_then_complete_observables()
+        {
+            var socket = new ReactiveClient("127.0.0.1", 1055);
+
+            bool receiverCompleted = false;
+            bool senderCompleted = false;
+
+            socket.Receiver.Subscribe(x => { }, () => receiverCompleted = true);
+            socket.Sender.Subscribe(x => { }, () => senderCompleted = true);
+
+            socket.Dispose();
+
+            Assert.True(receiverCompleted);
+            Assert.True(senderCompleted);
+        }
+
         [Fact(Skip = "Does not work from tests.")]
         public void when_reconnecting_then_raises_connected()
         {

--- a/ReactiveSockets/ReactiveListener.cs
+++ b/ReactiveSockets/ReactiveListener.cs
@@ -58,6 +58,7 @@
             listenerSubscription.Dispose();
             this.socketDisposable.Dispose();
             connections.ForEach(socket => socket.Dispose());
+            observable.OnCompleted();
         }
 
         /// <summary>

--- a/ReactiveSockets/ReactiveSocket.cs
+++ b/ReactiveSockets/ReactiveSocket.cs
@@ -225,13 +225,13 @@
             this.readSubscription = Observable.Defer(() => 
                     Observable.FromAsyncPattern<byte[], int, int, int>(stream.BeginRead, stream.EndRead)(buffer, 0, buffer.Length))
                 .Repeat()
-                .Where(x => x != -1)
+                .TakeWhile(x => x > 0)
                 .SelectMany(buffer.Take)
                 .Subscribe(x => this.received.Add(x), ex =>
                 {
                     Tracer.Log.ReactiveSocketReadFailed(ex);
                     Disconnect(false);
-                });
+                }, () => Disconnect(false));
         }
 
         /// <summary>

--- a/ReactiveSockets/ReactiveSocket.cs
+++ b/ReactiveSockets/ReactiveSocket.cs
@@ -264,9 +264,9 @@
             return Observable.Start(() => 
             {
                 Monitor.Enter(syncLock);
-                stream.Write(bytes, 0, bytes.Length);
+                try  { stream.Write(bytes, 0, bytes.Length); }
+                finally { Monitor.Exit(syncLock); }
             })
-            .Finally(() => Monitor.Exit(syncLock))
             .SelectMany(_ => bytes)
             .Do(x => sender.OnNext(x), ex => Disconnect())
             .ToTask(cancellation);

--- a/ReactiveSockets/ReactiveSocket.cs
+++ b/ReactiveSockets/ReactiveSocket.cs
@@ -1,8 +1,4 @@
-﻿using System.IO;
-using System.Reactive;
-using System.Reactive.Threading.Tasks;
-
-namespace ReactiveSockets
+﻿namespace ReactiveSockets
 {
     using System;
     using System.Collections.Concurrent;
@@ -14,6 +10,9 @@ namespace ReactiveSockets
     using System.Threading;
     using System.Threading.Tasks;
     using ReactiveSockets.Properties;
+    using System.IO;
+    using System.Reactive;
+    using System.Reactive.Threading.Tasks;
 
     /// <summary>
     /// Implements the reactive socket base class, which is used 


### PR DESCRIPTION
This PR does a few things, if you don't want all features, I can break them up:
- Rewrite some of the code to be "Rx-style"
- Call `OnComplete()` on the underlying Subjects for the exposed `IObservables` in `ReactiveListener` and `ReactiveSocket` when the classes are disposed. This allows any subcriptions of consumers to automatically be disposed.
- Fixed a bug that causes 100% CPU consumption when a connected socket closes the connection unexpectedly. This bug was present before my changes, but I fixed it in an "Rx-style"
