### PR TITLE
Limit the BlockingCollection in ReactiveSocket to 1MB of data

### DIFF
--- a/ReactiveSockets/ReactiveClient.cs
+++ b/ReactiveSockets/ReactiveClient.cs
@@ -22,7 +22,10 @@ namespace ReactiveSockets
         /// </summary>
         /// <param name="hostname">The host name or IP address of the TCP server to connect to.</param>
         /// <param name="port">The port to connect to.</param>
-        public ReactiveClient(string hostname, int port) : this(hostname, port, stream => stream) { }
+        /// <param name="maximumBufferSize">An optional value for the maximum number of bytes 
+        /// that is stored before TCP flow control kicks in.</param>
+        public ReactiveClient(string hostname, int port, int maximumBufferSize = MaximumBufferSize) 
+            : this(hostname, port, stream => stream, maximumBufferSize) { }
 
         /// <summary>
         /// Initializes the reactive client using a custom stream transform.
@@ -33,6 +36,8 @@ namespace ReactiveSockets
         /// <param name="port">The port to connect to.</param>
         /// <param name="streamTransform">The callback function to use to obtain the communication <see cref="Stream"/>.
         /// The callback is passed the original Stream from the underlying <see cref="TcpClient"/>.</param>
+        /// <param name="maximumBufferSize">An optional value for the maximum number of bytes 
+        /// that is stored before TCP flow control kicks in.</param>
         /// <example>
         /// Using with SSL:
         /// <code>
@@ -46,7 +51,8 @@ namespace ReactiveSockets
         /// } 
         /// </code>
         /// </example>
-        public ReactiveClient(string hostname, int port, Func<Stream, Stream> streamTransform)
+        public ReactiveClient(string hostname, int port, Func<Stream, Stream> streamTransform, int maximumBufferSize = MaximumBufferSize)
+            :base(maximumBufferSize)
         {
             this.hostname = hostname;
             this.port = port;

--- a/ReactiveSockets/ReactiveClient.cs
+++ b/ReactiveSockets/ReactiveClient.cs
@@ -23,7 +23,9 @@ namespace ReactiveSockets
         /// <param name="hostname">The host name or IP address of the TCP server to connect to.</param>
         /// <param name="port">The port to connect to.</param>
         /// <param name="maximumBufferSize">An optional value for the maximum number of bytes 
-        /// that is stored before TCP flow control kicks in.</param>
+        /// that is stored before TCP flow control kicks in.
+        /// The default value is <see cref="ReactiveSocket.MaximumBufferSize"/>
+        /// </param>
         public ReactiveClient(string hostname, int port, int maximumBufferSize = MaximumBufferSize) 
             : this(hostname, port, stream => stream, maximumBufferSize) { }
 
@@ -37,7 +39,9 @@ namespace ReactiveSockets
         /// <param name="streamTransform">The callback function to use to obtain the communication <see cref="Stream"/>.
         /// The callback is passed the original Stream from the underlying <see cref="TcpClient"/>.</param>
         /// <param name="maximumBufferSize">An optional value for the maximum number of bytes 
-        /// that is stored before TCP flow control kicks in.</param>
+        /// that is stored before TCP flow control kicks in.
+        /// The default value is <see cref="ReactiveSocket.MaximumBufferSize"/>
+        /// </param>
         /// <example>
         /// Using with SSL:
         /// <code>

--- a/ReactiveSockets/ReactiveSocket.cs
+++ b/ReactiveSockets/ReactiveSocket.cs
@@ -30,7 +30,9 @@
 
         // This allows protocols to be easily built by consuming 
         // bytes from the stream using Rx expressions.
-        private BlockingCollection<byte> received = new BlockingCollection<byte>();
+        // We use a maximum capacity of 1MB, so we don't fill the 
+        // collection endlessly and risk an OutOfMemoryException
+        private BlockingCollection<byte> received;
 
         // The receiver created from the above blocking collection.
         private IObservable<byte> receiver;
@@ -46,11 +48,16 @@
         private int receiveBufferSize = 8192;
 
         /// <summary>
+        /// The maximum number of bytes that is stored to process for the <see cref="Receiver"/> observable.
+        /// </summary>
+        public const int MaximumBufferSize = 1024 * 1024;
+
+        /// <summary>
         /// Initializes the socket with a previously accepted TCP 
         /// client connection. This overload is used by the <see cref="ReactiveListener"/>.
         /// </summary>
         internal ReactiveSocket(TcpClient client)
-            : this()
+            : this(MaximumBufferSize)
         {
             Tracer.Log.ReactiveSocketCreated();
             Connect(client);
@@ -60,8 +67,12 @@
         /// Protected constructor used by <see cref="ReactiveClient"/> 
         /// client.
         /// </summary>
-        protected internal ReactiveSocket()
+        protected internal ReactiveSocket(int maximumBufferSize)
         {
+            if(maximumBufferSize < 0)
+                throw new ArgumentOutOfRangeException("maximumBufferSize", "Maximum buffer size must be greater than 0");
+
+            received = new BlockingCollection<byte>(maximumBufferSize);
             receiver = received.GetConsumingEnumerable().ToObservable(TaskPoolScheduler.Default)
                 .TakeUntil(receiverTermination);
         }
@@ -107,7 +118,8 @@
         public IObservable<byte> Sender { get { return sender; } }
 
         /// <summary>
-        /// Gets or sets the size of the buffer for receiving data.
+        /// Gets or sets the <see cref="TcpClient.ReceiveBufferSize"/> of the 
+        /// underlying <see cref="TcpClient"/>.
         /// The default value is 8192 bytes.
         /// </summary>
         public int ReceiveBufferSize


### PR DESCRIPTION
This fixes a bug, where the sender could send endless data and risk an
`OutOfMemoryException` if the receiver couldn't keep up with the
processing of the data.

This basically re-enables flow control of the TCP protocol

1MB is an arbitrary value that I choose, because the maximum capacity of
a `BlockingCollection` cannot be changed later
